### PR TITLE
Cleaned up Redundant Camera/Drive Code

### DIFF
--- a/src/main/java/org/usfirst/frc/team3786/robot/Mappings.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/Mappings.java
@@ -16,16 +16,15 @@ import org.usfirst.frc.team3786.robot.commands.elevator.ElevatorChangeCommand;
 import org.usfirst.frc.team3786.robot.commands.elevator.ElevatorDownCommand;
 import org.usfirst.frc.team3786.robot.commands.elevator.ElevatorStopCommand;
 import org.usfirst.frc.team3786.robot.commands.elevator.ElevatorUpCommand;
-import org.usfirst.frc.team3786.robot.commands.climber.ClimbWhileLevelCommand;
 import org.usfirst.frc.team3786.robot.commands.climber.DriveToWallCommand;
 import org.usfirst.frc.team3786.robot.utils.XboxController;
 
 public class Mappings {
-	//Controller Inputs
+	// Controller Inputs
 	public final static int primaryControllerId = 0;
 	public final static int secondaryControllerId = 1;
 
-	//CAN Controllers
+	// CAN Controllers
 	public final static int leftMotor = 1; // Drive left 1, SPARK Max controller
 	public final static int rightMotor = 2; // Drive right 1, SPARK MAX controller
 
@@ -35,14 +34,14 @@ public class Mappings {
 	public final static int tiltMotor = 5; // Drive, Talon SRX
 	public final static int elevatorMotor = 12; // Lift, SPARK Max
 
-	//Analog Inputs
+	// Analog Inputs
 	public final static int UltrasonicSensor = 0;
-	
+
 	public static void setupDefaultMappings() {
-		
+
 		XboxController primary = OI.getPrimaryController();
-		primary.buttonA.whenPressed(new BrakeOnCommand());
-		primary.buttonA.whenReleased(new BrakeOffCommand());
+		// primary.buttonA.whenPressed(new BrakeOnCommand());
+		// primary.buttonA.whenReleased(new BrakeOffCommand());
 		primary.buttonB.whenPressed(new BoostOnCommand());
 		primary.buttonB.whenReleased(new BoostOffCommand());
 		primary.buttonX.whenPressed(new DriveToWallCommand());

--- a/src/main/java/org/usfirst/frc/team3786/robot/Robot.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/Robot.java
@@ -68,7 +68,6 @@ public class Robot extends TimedRobot {
 	public void robotPeriodic() {
 		Scheduler.getInstance().run();
 		gyro.run();
-		Cameras.run();
 		byte bright = (byte) SmartDashboard.getNumber("LED.BRIGHTNESS", -1);
 		if (bright == -1) {
 			SmartDashboard.putNumber("LED.BRIGHTNESS", 255);

--- a/src/main/java/org/usfirst/frc/team3786/robot/commands/drive/TankDriveCommand.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/commands/drive/TankDriveCommand.java
@@ -31,8 +31,7 @@ public class TankDriveCommand extends Command {
 		// When the number is positive, the wheels go backwards.
 		double throttle = OI.getRobotThrottle();
 		double turn = OI.getRobotTurn();
-		double leftTrigger = OI.getPrimaryController().getLeftTrigger();
-		ChargerDriveSubsystem.getInstance().arcadeDrive(throttle * (leftTrigger - 1) / 2.0, -turn * (leftTrigger - 1) / 2.0);
+		ChargerDriveSubsystem.getInstance().arcadeDrive(-throttle, turn);
 	}
 
 	// Make this return true when this Command no longer needs to run execute()

--- a/src/main/java/org/usfirst/frc/team3786/robot/subsystems/ChargerDriveSubsystem.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/subsystems/ChargerDriveSubsystem.java
@@ -52,17 +52,15 @@ public class ChargerDriveSubsystem extends Subsystem {
 
 	public void arcadeDrive(double speed, double turnRate) {
 		Dashboard.getInstance().putBoolean(true, "Boost", boost);
-		Dashboard.getInstance().putBoolean(true, "Break", brake);
+		// Dashboard.getInstance().putBoolean(true, "Break", brake);
 		Dashboard.getInstance().putNumber(false, "Driving Speed", speed);
 		Dashboard.getInstance().putNumber(false, "TurnRate", turnRate);
-		if(this.brake) {
-			speed *= 0.0;
-			turnRate *= 0.0;
-		}
-
-		if(this.boost) {
-			speed *= 2.0;
-			turnRate *= 2.0;
+		/*
+		 * if (this.brake) { speed *= 0.0; turnRate *= 0.0; }
+		 */
+		if (!this.boost) {
+			speed *= 0.75;
+			turnRate *= 0.75;
 		}
 
 		differentialDrive.arcadeDrive(speed, turnRate);

--- a/src/main/java/org/usfirst/frc/team3786/robot/subsystems/NeoDriveSubsystem.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/subsystems/NeoDriveSubsystem.java
@@ -32,7 +32,7 @@ public class NeoDriveSubsystem extends Subsystem {
 		left = new CANSparkMax(Mappings.leftMotor, MotorType.kBrushless);
 		right = new CANSparkMax(Mappings.rightMotor, MotorType.kBrushless);
 		left.setSmartCurrentLimit(35);
-		right.setSmartCurrentLimit(35);	
+		right.setSmartCurrentLimit(35);
 		left.setRampRate(0.1);
 		right.setRampRate(0.1);
 
@@ -56,14 +56,12 @@ public class NeoDriveSubsystem extends Subsystem {
 		Dashboard.getInstance().putBoolean(true, "Break", kkBrake);
 		Dashboard.getInstance().putNumber(false, "Driving Speed", speed);
 		Dashboard.getInstance().putNumber(false, "TurnRate", turnRate);
-		if(this.kkBrake) {
+		if (this.kkBrake) {
 			speed *= 0.0;
 			turnRate *= 0.0;
-		}
-
-		if(this.boost) {
-			speed *= 2.0;
-			turnRate *= 2.0;
+		} else if (!this.boost) {
+			speed *= 0.75;
+			turnRate *= 0.75;
 		}
 
 		differentialDrive.arcadeDrive(speed, turnRate);

--- a/src/main/java/org/usfirst/frc/team3786/robot/subsystems/vision/Cameras.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/subsystems/vision/Cameras.java
@@ -7,31 +7,32 @@ import io.github.pseudoresonance.pixy2api.links.SPILink;
 public class Cameras {
 
     private static UsbCamera drive = null;
-    private static PixyCamera pixy = null;
+    private static PixyCamera pixy1 = null;
+    private static PixyCamera pixy2 = null;
 
     public static void setup() {
         initDrive();
-        pixy = new PixyCamera(new SPILink());
+        pixy1 = new PixyCamera(new SPILink());
+        pixy2 = new PixyCamera(new SPILink(), 1);
     }
 
-    public static void run() {
-        pixy.run();
+    public static PixyCamera getPixyCamera1() {
+        return pixy1;
     }
 
-    public static PixyCamera getPixyCamera() {
-        return pixy;
+    public static PixyCamera getPixyCamera2() {
+        return pixy2;
     }
 
     public static void initDrive() {
         drive = CameraServer.getInstance().startAutomaticCapture();
         if (drive != null) {
-			//drive.setVideoMode(PixelFormat.kBGR, 320, 240, 30);
-			drive.setResolution(320, 240);
+            drive.setResolution(320, 240);
             drive.setFPS(30);
-            drive.setWhiteBalanceManual(5000);
-			drive.setBrightness(50);
-            drive.setExposureManual(50);
-		}
+            drive.setWhiteBalanceManual(4500);
+            drive.setExposureAuto();
+            drive.setBrightness(50);
+        }
     }
 
 }

--- a/src/main/java/org/usfirst/frc/team3786/robot/subsystems/vision/PixyCamera.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/subsystems/vision/PixyCamera.java
@@ -1,7 +1,6 @@
 package org.usfirst.frc.team3786.robot.subsystems.vision;
 
 import io.github.pseudoresonance.pixy2api.Pixy2;
-import io.github.pseudoresonance.pixy2api.Pixy2CCC;
 import io.github.pseudoresonance.pixy2api.links.Link;
 
 public class PixyCamera {
@@ -16,10 +15,6 @@ public class PixyCamera {
 	public PixyCamera(Link link, int arg) {
 		pixy = Pixy2.createInstance(link);
 		pixy.init(arg);
-	}
-
-	public void run() {
-		pixy.getCCC().getBlocks(false, Pixy2CCC.CCC_SIG1 | Pixy2CCC.CCC_SIG2, 25);
 	}
 
 	public Pixy2 getPixy() {

--- a/src/main/java/org/usfirst/frc/team3786/robot/subsystems/vision/TargetBall.java
+++ b/src/main/java/org/usfirst/frc/team3786/robot/subsystems/vision/TargetBall.java
@@ -5,13 +5,15 @@ import edu.wpi.first.wpilibj.command.Command;
 import org.usfirst.frc.team3786.robot.Dashboard;
 
 import org.usfirst.frc.team3786.robot.subsystems.vision.Cameras;
+
+import io.github.pseudoresonance.pixy2api.Pixy2CCC;
 import io.github.pseudoresonance.pixy2api.Pixy2CCC.Block;
 
 public class TargetBall extends Command {
-    
-    private static ArrayList<Block> blocks = Cameras.getPixyCamera().getPixy().getCCC().getBlocks();
 
-    private static final int blockSignature = 2;
+    private static ArrayList<Block> blocks = Cameras.getPixyCamera1().getPixy().getCCC().getBlocks();
+
+    private static final int blockSignature = 1;
 
     public TargetBall() {
     }
@@ -19,9 +21,10 @@ public class TargetBall extends Command {
     @Override
     protected void initialize() {
     }
-    
+
     @Override
     protected void execute() {
+        Cameras.getPixyCamera1().getPixy().getCCC().getBlocks(false, Pixy2CCC.CCC_SIG1, 25);
         Block largestBlock = null;
 
         for (Block block : blocks) {


### PR DESCRIPTION
We tested driving the robot around, and found that around 75% speed by default was good, but we also found that by the time you got to stopping the robot with the brake button, the robot was already stopped, or close enough that it was a waste of time to move your hand out of position. Unfortunately, it just wasn't very helpful in practice, so I disabled it to make room for any other controls.

I also simplified the math for the driving by removing the redundant multiplication, which also makes it easier to read and got better camera settings to make it more usable.